### PR TITLE
Fix Spotify login failure caused by extra callback query parameters

### DIFF
--- a/Backend/ConnectionManager.cs
+++ b/Backend/ConnectionManager.cs
@@ -405,9 +405,22 @@ namespace Backend
                 return;
             }
 
-            // extract token
-            var code = ctx.Request.Url.ToString().Replace($"{CALLBACK_URL}?code=", "");
-            Logger.Information("got token");
+            // extract authorization code
+            var error = ctx.Request.QueryString["error"];
+            var code = ctx.Request.QueryString["code"];
+            
+            if (!string.IsNullOrWhiteSpace(error))
+            {
+                Logger.Information($"Spotify login returned error: {error}");
+            }
+            else if (string.IsNullOrWhiteSpace(code))
+            {
+                Logger.Information("Spotify login callback did not include an authorization code");
+            }
+            else
+            {
+                Logger.Information("got authorization code");
+            }
 
             // create spotify client
             var tokenRequest = new PKCETokenRequest(CLIENT_ID, code, new Uri(CALLBACK_URL), verifier);


### PR DESCRIPTION
Spotify now returns additional query parameters on the callback URL, such as `ubi`.

The previous code extracted the authorization code by replacing the callback URL prefix from the full URL string. When extra query parameters were present, the app passed `code&ubi=...` to Spotify instead of only the authorization code, causing Spotify to reject the token exchange with `invalid_grant`.

This changes the callback handling to read the `code` parameter directly from the query string.

Tested locally:
- Spotify login opens correctly
- Callback is received on 127.0.0.1:63847
- Token exchange succeeds
- Backend API starts normally on 127.0.0.1:63848